### PR TITLE
[WIP] Enable training SAEs on vision models

### DIFF
--- a/sae/config.py
+++ b/sae/config.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import AbstractSet
 
 from simple_parsing import Serializable, list_field
 
@@ -67,14 +68,15 @@ class TrainConfig(Serializable):
     save_every: int = 1000
     """Save SAEs every `save_every` steps."""
 
-    instance_dims: tuple = (0, 1)
+    sample_dims: AbstractSet[int] = frozenset({0, 1})
+    """Dimensions containing SAE inputs."""
 
-    feature_dims: tuple = (2,)
+    feature_dims: AbstractSet[int] = frozenset({2})
+    """Dimensions of SAE inputs."""
     
     log_to_wandb: bool = True
     run_name: str | None = None
     wandb_log_frequency: int = 1
-    
 
     def __post_init__(self):
         assert not (

--- a/sae/config.py
+++ b/sae/config.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import AbstractSet
 
 from simple_parsing import Serializable, list_field
 
@@ -68,12 +67,6 @@ class TrainConfig(Serializable):
     save_every: int = 1000
     """Save SAEs every `save_every` steps."""
 
-    sample_dims: AbstractSet[int] = frozenset({0, 1})
-    """Dimensions containing SAE inputs."""
-
-    feature_dims: AbstractSet[int] = frozenset({2})
-    """Dimensions of SAE inputs."""
-    
     log_to_wandb: bool = True
     run_name: str | None = None
     wandb_log_frequency: int = 1

--- a/sae/config.py
+++ b/sae/config.py
@@ -67,9 +67,14 @@ class TrainConfig(Serializable):
     save_every: int = 1000
     """Save SAEs every `save_every` steps."""
 
+    instance_dims: tuple = (0, 1)
+
+    feature_dims: tuple = (2,)
+    
     log_to_wandb: bool = True
     run_name: str | None = None
     wandb_log_frequency: int = 1
+    
 
     def __post_init__(self):
         assert not (

--- a/sae/sae.py
+++ b/sae/sae.py
@@ -180,7 +180,7 @@ class Sae(nn.Module):
 
     def encode(self, x: Tensor) -> EncoderOutput:
         """Encode the input and select the top-k latents."""
-        return self.select_topk(self.pre_acts(x))
+        return EncoderOutput(*self.select_topk(self.pre_acts(x)))
 
     def decode(self, top_acts: Tensor, top_indices: Tensor) -> Tensor:
         assert self.W_dec is not None, "Decoder weight was not initialized."

--- a/sae/trainer.py
+++ b/sae/trainer.py
@@ -64,6 +64,7 @@ Available modules:
 
         device = model.device
         dummy_inputs = dummy_inputs if dummy_inputs is not None else model.dummy_inputs
+        self.key = list(dummy_inputs.keys())[0]
         input_widths = resolve_widths(model, cfg.hookpoints, dummy_inputs)
         unique_widths = set(input_widths.values())
 
@@ -226,7 +227,7 @@ Available modules:
             output_dict.clear()
 
             # Bookkeeping for dead feature detection
-            num_tokens_in_step += batch["input_ids"].numel()
+            num_tokens_in_step += batch[self.key].numel()
 
             # Forward pass on the model to get the next batch of activations            
             handles = [
@@ -234,7 +235,8 @@ Available modules:
             ]
             try:
                 with torch.no_grad():
-                    self.model(batch["input_ids"].to(device))
+                    self.model(batch[self.key].to(device))
+                    
             finally:
                 for handle in handles:
                     handle.remove()

--- a/sae/trainer.py
+++ b/sae/trainer.py
@@ -248,11 +248,11 @@ class SaeTrainer:
                 inputs = input_dict.get(name, outputs)
                 raw = self.saes[name]           # 'raw' never has a DDP wrapper
 
-                outputs = outputs.permute(*self.cfg.instance_dims, *self.cfg.feature_dims)
+                outputs = outputs.permute(*self.cfg.sample_dims, *self.cfg.feature_dims)
                 outputs = outputs.reshape(-1, raw.d_in)
 
                 if self.cfg.transcode:
-                    inputs = inputs.permute(*self.cfg.instance_dims, *self.cfg.feature_dims)
+                    inputs = inputs.permute(*self.cfg.sample_dims, *self.cfg.feature_dims)
                     inputs = inputs.reshape(-1, raw.d_in)
 
                 # On the first iteration, initialize the decoder bias

--- a/sae/utils.py
+++ b/sae/utils.py
@@ -1,6 +1,5 @@
 import os
 from typing import Any, Type, TypeVar, cast
-from math import prod
 
 import torch
 from accelerate.utils import send_to_device
@@ -63,7 +62,7 @@ def get_layer_list(model: PreTrainedModel) -> tuple[str, nn.ModuleList]:
 @torch.inference_mode()
 def resolve_widths(
     model: PreTrainedModel, module_names: list[str], dummy_inputs: dict[str, Tensor], 
-    dims: set[int] = {-1},
+    dim: int = -1,
 ) -> dict[str, int]:
     """Find number of output dimensions for the specified modules."""
     module_to_name = {
@@ -77,8 +76,7 @@ def resolve_widths(
             output, *_ = output
 
         name = module_to_name[module]
-
-        shapes[name] = prod(output.shape[d] for d in dims)
+        shapes[name] = output.shape[dim]
 
     handles = [
         mod.register_forward_hook(hook) for mod in module_to_name

--- a/sae/utils.py
+++ b/sae/utils.py
@@ -63,7 +63,7 @@ def get_layer_list(model: PreTrainedModel) -> tuple[str, nn.ModuleList]:
 @torch.inference_mode()
 def resolve_widths(
     model: PreTrainedModel, module_names: list[str], dummy_inputs: dict[str, Tensor], 
-    dims: tuple[int] = (-1,),
+    dims: set[int] = {-1},
 ) -> dict[str, int]:
     """Find number of output dimensions for the specified modules."""
     module_to_name = {


### PR DESCRIPTION
- Update input flattening to support hidden tensors with more batch dimensions
- Enable specifying dummy inputs - the default `transformers` dummy input is of shape [3, 5] and uses the 'input_ids' key
- Improve logging when hookpoints aren't specified correctly

TODO:

- [x] Enable training from command line (replace tokenizer with image processor)
- [ ] Decide whether to support image data in MemmapDataset 
- [ ] Check if we can detect vision models and produce correct dummy input (key value, image shape) in the init
  
Maybe like

```
processor = AutoProcessor.from_pretrained(args.model, token=args.hf_token)
target_column = "pixel_values" if isinstance(processor, BaseImageProcessor) else "input_ids"
```

process.size.shortest_edge exists but no channel count