### PR TITLE
auxk loss: sign flip for correct prediction of the residual

### DIFF
--- a/sparsify/sae.py
+++ b/sparsify/sae.py
@@ -214,7 +214,7 @@ class Sae(nn.Module):
             sae_out += x.to(self.dtype) @ self.W_skip.mT
 
         # Compute the residual
-        e = sae_out - y
+        e = y - sae_out
 
         # Used as a denominator for putting everything on a reasonable scale
         total_variance = (y - y.mean(0)).pow(2).sum()


### PR DESCRIPTION
Yo !

The current implementation of the auxiliary loss differs from the description provided in the OpenAI paper. Although minimizing `(a - b)^2` is mathematically equivalent to minimizing `(b - a)^2`, in our context the order matters because of how the residual is defined (we define `a` as `(c - d)` or `(d - c)` is not the same). 

#### Current Implementation

In the code, the residual is defined as:
```
e = sae_out - y
```
and the auxiliary loss is computed as:
```
auxk_loss = sum((e_hat - e)^2)
```
This expands to:
```
auxk_loss = sum((e_hat - (sae_out - y))^2)
```
Thus, the minimization effectively drives:
```
e_hat - sae_out + y
```
which is not equivalent to the desired formulation.

#### Correct Formulation

The intended approach is to define the residual so that it aligns with the correction we desire. There are two natural variants:

*Variant 1*: Define the Residual as
```
e = y - y_pred
```
Then, the auxiliary loss becomes:
```
L1 = (e_hat - (y - y_pred))^2 = (e_hat + y_pred - y)^2
```
Minimizing L1 drives:
```
e_hat -> y - y_pred
```
This formulation is natural as we intend for e_hat to serve as the correction added to the prediction y_pred
```
y_pred + e_hat = y
```
when the loss is minimized  (i.e., y_pred + e_hat should be close to y).

---

*Variant 2*: Define the Residual as
```
e = y_pred - y
```
Then, the auxiliary loss becomes:
```
L2 = (e_hat - (y_pred - y))^2 = (e_hat + y - y_pred)^2
```
Minimizing L2 drives:
```
e_hat -> y_pred - y
```
which is exactly the negative of the target in Variant 1.
```
y_pred - e_hat = y
```
when the loss is minimized

I sent a mail 2 month ago about this, but i saw no response, so i opened the PR :) 