### PR TITLE
Add k decay schedule

### DIFF
--- a/sparsify/config.py
+++ b/sparsify/config.py
@@ -62,7 +62,7 @@ class TrainConfig(Serializable):
 
     k_decay_steps: int = 0
     """Number of steps over which to decay the number of active latents. Starts at
-    input width * 2 and decays to k."""
+    input width * 1.5 and decays to k."""
 
     auxk_alpha: float = 0.0
     """Weight of the auxiliary loss term."""

--- a/sparsify/config.py
+++ b/sparsify/config.py
@@ -62,7 +62,7 @@ class TrainConfig(Serializable):
 
     k_decay_steps: int = 0
     """Number of steps over which to decay the number of active latents. Starts at
-    input width * 1.5 and decays to k."""
+    input width * 1.5 and decays to k. Experimental feature."""
 
     auxk_alpha: float = 0.0
     """Weight of the auxiliary loss term."""

--- a/sparsify/config.py
+++ b/sparsify/config.py
@@ -62,7 +62,7 @@ class TrainConfig(Serializable):
 
     k_decay_steps: int = 0
     """Number of steps over which to decay the number of active latents. Starts at
-    input width * 1.5 and decays to k. Experimental feature."""
+    input width * 10 and decays to k. Experimental feature."""
 
     auxk_alpha: float = 0.0
     """Weight of the auxiliary loss term."""

--- a/sparsify/config.py
+++ b/sparsify/config.py
@@ -58,6 +58,11 @@ class TrainConfig(Serializable):
     """Base LR. If None, it is automatically chosen based on the number of latents."""
 
     lr_warmup_steps: int = 1000
+    """Number of steps over which to warm up the learning rate."""
+
+    k_decay_steps: int = 0
+    """Number of steps over which to decay the number of active latents. Starts at
+    input width * 2 and decays to k."""
 
     auxk_alpha: float = 0.0
     """Weight of the auxiliary loss term."""

--- a/sparsify/trainer.py
+++ b/sparsify/trainer.py
@@ -115,6 +115,9 @@ class Trainer:
             self.optimizer, cfg.lr_warmup_steps, num_examples // cfg.batch_size
         )
 
+        self.initial_k = list(input_widths.values())[0] * 2
+        self.final_k = self.cfg.sae.k
+
     def load_state(self, path: str):
         """Load the trainer state from disk."""
         device = self.model.device
@@ -152,6 +155,15 @@ class Trainer:
         for name, sae in self.saes.items():
             load_model(sae, f"{path}/{name}/sae.safetensors", device=str(device))
 
+    def get_current_k(self) -> int:
+        """Get the current k value based on a linear decay schedule."""
+        if self.global_step >= self.cfg.k_decay_steps:
+            return self.final_k
+        
+        progress = self.global_step / self.cfg.k_decay_steps
+        return round(self.initial_k * (1 - progress) + self.final_k * progress)
+    
+    
     def fit(self):
         # Use Tensor Cores even for fp32 matmuls
         torch.set_float32_matmul_precision("high")
@@ -236,6 +248,10 @@ class Trainer:
             # Remember the inputs if we're training a transcoder
             if self.cfg.sae.transcode:
                 input_dict[name] = inputs.flatten(0, 1)
+
+        k = self.get_current_k()
+        for name, sae in self.saes.items():
+            sae.cfg.k = k
 
         for batch in dl:
             input_dict.clear()
@@ -347,6 +363,10 @@ class Trainer:
                 self.optimizer.zero_grad()
                 self.lr_scheduler.step()
 
+                k = self.get_current_k()
+                for name, sae in self.saes.items():
+                    sae.cfg.k = k
+
                 ###############
                 with torch.no_grad():
                     # Update the dead feature mask
@@ -394,6 +414,8 @@ class Trainer:
                         info.update({k: v for out in outputs for k, v in out.items()})
 
                     if rank_zero:
+                        info["k"] = k
+
                         wandb.log(info, step=step)
 
                 if (step + 1) % self.cfg.save_every == 0:

--- a/sparsify/trainer.py
+++ b/sparsify/trainer.py
@@ -115,7 +115,7 @@ class Trainer:
             self.optimizer, cfg.lr_warmup_steps, num_examples // cfg.batch_size
         )
 
-        self.initial_k = list(input_widths.values())[0] * 2
+        self.initial_k = round(list(input_widths.values())[0] * 1.5)
         self.final_k = self.cfg.sae.k
 
     def load_state(self, path: str):

--- a/sparsify/trainer.py
+++ b/sparsify/trainer.py
@@ -115,7 +115,8 @@ class Trainer:
             self.optimizer, cfg.lr_warmup_steps, num_examples // cfg.batch_size
         )
 
-        self.initial_k = round(list(input_widths.values())[0] * 1.5)
+        num_latents = list(self.saes.values())[0].num_latents
+        self.initial_k = min(num_latents, round(list(input_widths.values())[0] * 10))
         self.final_k = self.cfg.sae.k
 
     def load_state(self, path: str):


### PR DESCRIPTION
Add optional k decay schedule to fix issue with SmolLM transcoders where a large number of dead neurons form. Potentially caused by the input activation norm being much lower than the output activation norm.

Initial k and num k decay steps are both hyperparameters with unclear optimal values, although there appears to be some structure to the responses - higher initial ks generally result in fewer dead neurons, and picking a custom initial k for SmolLM around the empirical k decay value where dead neurons started to form resulted in a good run with ~0 dead neurons. Only exposing num k decay steps for now to limit config size growth.
