### PR TITLE
Switch to Schedule-Free Signum (Sign SGD) optimizer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "huggingface-hub",
     "natsort",  # For sorting module names
     "safetensors",
+    "schedulefree",
     "simple-parsing",
     "torch",
     "transformers",

--- a/sparsify/config.py
+++ b/sparsify/config.py
@@ -45,7 +45,7 @@ TranscoderConfig = partial(SparseCoderConfig, transcode=True)
 class TrainConfig(Serializable):
     sae: SparseCoderConfig
 
-    batch_size: int = 8
+    batch_size: int = 32
     """Batch size measured in sequences."""
 
     grad_acc_steps: int = 1
@@ -56,8 +56,6 @@ class TrainConfig(Serializable):
 
     lr: float | None = None
     """Base LR. If None, it is automatically chosen based on the number of latents."""
-
-    lr_warmup_steps: int = 1000
 
     auxk_alpha: float = 0.0
     """Weight of the auxiliary loss term."""

--- a/sparsify/sign_sgd.py
+++ b/sparsify/sign_sgd.py
@@ -1,0 +1,23 @@
+import torch
+from torch.optim import Optimizer
+
+
+class SignSGD(Optimizer):
+    """Steepest descent in the L-infty norm. From <https://arxiv.org/abs/1802.04434>"""
+
+    def __init__(self, params, lr: float = 1e-3):
+        if lr <= 0.0:
+            raise ValueError(f"Invalid learning rate: {lr}")
+
+        defaults = {"lr": lr}
+        super(SignSGD, self).__init__(params, defaults)
+
+    @torch.no_grad()
+    def step(self, closure: None = None) -> None:
+        assert closure is None, "Closure is not supported."
+
+        for group in self.param_groups:
+            lr = group["lr"]
+            for p in group["params"]:
+                if p.grad is not None:
+                    p.add_(p.grad.sign(), alpha=-lr)

--- a/sparsify/trainer.py
+++ b/sparsify/trainer.py
@@ -86,7 +86,7 @@ class Trainer:
             {
                 "params": sae.parameters(),
                 # Auto-select LR using 1 / sqrt(d) scaling law from Fig 3 of the paper
-                "lr": cfg.lr or 5e-3 / (sae.num_latents / (2**14)) ** 0.5,
+                "lr": cfg.lr or 3e-3 / (sae.num_latents / (2**14)) ** 0.5,
             }
             for sae in self.saes.values()
         ]

--- a/sparsify/utils.py
+++ b/sparsify/utils.py
@@ -62,7 +62,7 @@ def resolve_widths(
 # Fallback implementation of SAE decoder
 def eager_decode(top_indices: Tensor, top_acts: Tensor, W_dec: Tensor):
     return nn.functional.embedding_bag(
-        top_indices, W_dec.mT, per_sample_weights=top_acts, mode='sum'
+        top_indices, W_dec.mT, per_sample_weights=top_acts, mode="sum"
     )
 
 
@@ -77,7 +77,7 @@ except ImportError:
     decoder_impl = eager_decode
     print("Triton not installed, using eager implementation of SAE decoder.")
 else:
-    if os.environ.get("SAE_DISABLE_TRITON") == "1":
+    if os.environ.get("SPARSIFY_DISABLE_TRITON") == "1":
         print("Triton disabled, using eager implementation of SAE decoder.")
         decoder_impl = eager_decode
     else:


### PR DESCRIPTION
It turns out that [Sign SGD](https://arxiv.org/abs/1802.04434) (simply descending the elementwise sign of the stochastic gradient) is an amazing optimizer for training SAEs and transcoders. It dramatically reduces the number of dead neurons in cases where that's a problem with Adam, presumably because it aggressively magnifies the updates applied to infrequent features, while clipping the update applied to frequent features for enhanced training stability. Convergence is greatly accelerated and often ends up at a lower final FVU.

Adding a [schedule-free wrapper](https://arxiv.org/abs/2405.15682) makes it even better, both in terms of convergence speed and dead neuron reduction. We also quadruple the default batch size, since that seems to enhance final FVU and reduce dead neurons, especially with the new optimizer.