### PR TITLE
feat(): add custom dir to save checkpoints

### DIFF
--- a/sparsify/config.py
+++ b/sparsify/config.py
@@ -97,6 +97,8 @@ class TrainConfig(Serializable):
     run_name: str | None = None
     wandb_log_frequency: int = 1
 
+    save_dir: str = 'checkpoints'
+
     def __post_init__(self):
         assert not (
             self.layers and self.layer_stride != 1

--- a/sparsify/trainer.py
+++ b/sparsify/trainer.py
@@ -576,7 +576,7 @@ class Trainer:
     def save(self):
         """Save the SAEs to disk."""
 
-        path = f'checkpoints/{self.cfg.run_name}' or "checkpoints/unnamed"
+        path = f'{self.cfg.save_dir}/{self.cfg.run_name or "unnamed"}'
         rank_zero = not dist.is_initialized() or dist.get_rank() == 0
 
         for optimizer in self.optimizers:


### PR DESCRIPTION
I needed to specify a directory to save the checkpoints, as in the cluster I am using the storage in the node where I have the code is pretty limited.

Also, there was a bug regarding unnamed training runs (they would just be under `checkpoints/None`