### PR TITLE
fix: hang when the number of examples is indivisible across processes

### DIFF
--- a/sparsify/__main__.py
+++ b/sparsify/__main__.py
@@ -134,6 +134,10 @@ def load_artifacts(
         if limit := args.max_examples:
             dataset = dataset.select(range(limit))
 
+    # Drop examples that are indivisible across processes to prevent deadlock
+    remainder_examples = len(dataset) % dist.get_world_size()
+    dataset = dataset.select(range(len(dataset) - remainder_examples))
+
     return model, dataset
 
 


### PR DESCRIPTION
Fix the `distribute_modules` bug by ensuring the number of examples is divisible by world size.

Closes https://github.com/EleutherAI/sparsify/issues/68