### PR TITLE
feat: Exclude tokens defined by user from training

### DIFF
--- a/sparsify/config.py
+++ b/sparsify/config.py
@@ -82,6 +82,9 @@ class TrainConfig(Serializable):
     dead_feature_threshold: int = 10_000_000
     """Number of tokens after which a feature is considered dead."""
 
+    exclude_tokens: list[int] = list_field()
+    """List of tokens to ignore during sparse coders training."""
+
     hookpoints: list[str] = list_field()
     """List of hookpoints to train sparse coders on."""
 


### PR DESCRIPTION
Implements the feature proposed in [104](https://github.com/EleutherAI/sparsify/issues/104).

### Implementation Details

- Added `exclude_tokens` flag (`config.py`):
```python
exclude_tokens: list[int] = list_field()
"""List of tokens to ignore in sparse coders loss computation."""
```
- During training, the loss won't be computed on activations corresponding to tokens from `exclude_tokens`
- **Supports** single(multi)-gpu training, `--distribute_modules` functionality

### Usage Example
```bash
python -m sparsify meta-llama/Llama-3.1-8B togethercomputer/RedPajama-Data-1T-Sample --exclude_tokens 128000 128001
```

---

### Tests

Compared training of SAEs on residual stream without masking, and with masking `BOS`, `EOS` tokens. Configuration **with masking**:
```bash
python -m sparsify meta-llama/Llama-3.1-8B DKYoon/SlimPajama-6B --exclude_tokens 128000 128001
```

For each scenario, run experiments with different optimizers: **adam** and **signum**.

#### Results:
- **Without masking**: training SAEs on residual stream with **signum** is unstable and diverges, **adam** works fine. 
  - The **FVU** metric is very low due to the high variance of `BOS` token activations.
- **With masking**: training is _**stable**_ both with **signum** and **adam**, with the first one converging faster, but they seem to reach similar performance by the end of training.

#### Wandb Plots

- **Without masking** (`TopK` is signum, `TopK-adam` is adam):

<img width="1320" height="628" alt="Screenshot 2025-07-21 at 11 37 35" src="https://github.com/user-attachments/assets/f65a2181-1206-4a66-92f9-4410351581b3" />

- **With masking** (`TopK-signum` is signum, `TopK-adam-v2` is adam):

<img width="1321" height="634" alt="Screenshot 2025-07-21 at 11 39 47" src="https://github.com/user-attachments/assets/8679ecdc-7539-4d20-bc40-4cb116a21820" />