### PR TITLE
Evaluate SAEs with KL divergence when grafted into the model

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,0 +1,54 @@
+import torch
+from datasets import load_dataset
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from sparsify import SaeConfig, Trainer, TrainConfig
+from sparsify.data import chunk_and_tokenize
+
+MODEL = "EleutherAI/pythia-70m"
+train_split = "train[:2%]"
+eval_split = "train[:1%]"
+
+print("Loading raw datasets...")
+train_raw = load_dataset("NeelNanda/pile-10k", split=train_split)
+eval_raw = load_dataset("NeelNanda/pile-10k", split=eval_split)
+tokenizer = AutoTokenizer.from_pretrained(MODEL, use_fast=True)
+tokenizer.model_max_length = 64
+if tokenizer.pad_token is None:
+    tokenizer.pad_token = tokenizer.eos_token  
+print("Tokenizing datasets...")
+train_ds = chunk_and_tokenize(train_raw, tokenizer, max_seq_len=64)
+eval_ds = chunk_and_tokenize(eval_raw, tokenizer, max_seq_len=64)
+
+print(f"Train dataset size: {len(train_ds)}")
+print(f"Eval dataset size: {len(eval_ds)}")
+
+# ---------------------------
+# Load tiny GPT (Pythia-70M)
+# ---------------------------
+gpt = AutoModelForCausalLM.from_pretrained(
+    MODEL,
+    device_map="auto",   
+    torch_dtype=torch.float32,
+)
+
+# ---------------------------
+# Training config
+# ---------------------------
+cfg = TrainConfig(
+    sae=SaeConfig(),
+    batch_size=1,             
+    grad_acc_steps=1,
+    micro_acc_steps=1,
+    loss_fn="kl",             
+    wandb_log_frequency=50,   
+    save_every=100,           
+    run_name="tiny-gpt2-kl",
+    log_to_wandb=False,      
+)
+
+# ---------------------------
+# Trainer
+# ---------------------------
+trainer = Trainer(cfg, train_ds, gpt, eval_dataset=eval_ds)
+trainer.fit()

--- a/sparsify/__main__.py
+++ b/sparsify/__main__.py
@@ -40,7 +40,8 @@ class RunConfig(TrainConfig):
 
     ctx_len: int = 2048
     """Context length to use for training."""
-
+    # Use a dummy encoding function to prevent the token from being saved
+    # to disk in plain text
     hf_token: str | None = field(default=None, encoding_fn=lambda _: None)
     """Huggingface API token for downloading models."""
 

--- a/sparsify/__main__.py
+++ b/sparsify/__main__.py
@@ -163,7 +163,9 @@ def run():
 
     args = parse(RunConfig)
 
+    # Prevent ranks other than 0 from printing
     with nullcontext() if rank == 0 else redirect_stdout(None):
+        # Awkward hack to prevent other ranks from duplicating data preprocessing
         if not ddp or rank == 0:
             model, dataset, eval_dataset = load_artifacts(args, rank)
         if ddp:

--- a/sparsify/__main__.py
+++ b/sparsify/__main__.py
@@ -81,7 +81,7 @@ def load_artifacts(
         dtype = torch.bfloat16
     else:
         dtype = torch.float32
-
+        # End-to-end training requires a model with a causal LM head
     model_cls = AutoModel if args.loss_fn == "fvu" else AutoModelForCausalLM
     model = model_cls.from_pretrained(
         args.model,
@@ -92,7 +92,7 @@ def load_artifacts(
             else None
         ),
         revision=args.revision,
-        dtype=dtype,  # ✅ replaces deprecated torch_dtype
+        dtype=dtype, 
         token=args.hf_token,
     )
 
@@ -133,8 +133,6 @@ def load_artifacts(
     eval_dataset = None
     if args.eval_split:
         eval_dataset = prepare_dataset(args.eval_split)
-        print(f"Eval dataset size: {len(eval_dataset)}")
-
     return model, dataset, eval_dataset
 
 
@@ -169,11 +167,9 @@ def run():
         if args.eval_split:
             print(f"Evaluating on split '{args.eval_split}'")
         print(f"Storing model weights in {model.dtype}")
-
-        # ✅ Ensure training won’t silently skip
         if args.epochs == 0 and args.max_steps == 0:
             args.epochs = 1
-            print("⚠️  No training length specified, defaulting to epochs=1")
+            print("No training length specified, defaulting to epochs=1")
 
         trainer = Trainer(args, dataset, model, eval_dataset=eval_dataset)
 

--- a/sparsify/config.py
+++ b/sparsify/config.py
@@ -104,6 +104,7 @@ class TrainConfig(Serializable):
     save_best: bool = False
     """Save the best checkpoint found for each hookpoint."""
     eval_every: int = 300
+    """eval steps """
     finetune: str | None = None
     """Finetune the sparse coders from a pretrained checkpoint."""
 

--- a/sparsify/config.py
+++ b/sparsify/config.py
@@ -103,7 +103,7 @@ class TrainConfig(Serializable):
 
     save_best: bool = False
     """Save the best checkpoint found for each hookpoint."""
-
+    eval_every: int = 300 
     finetune: str | None = None
     """Finetune the sparse coders from a pretrained checkpoint."""
 

--- a/sparsify/config.py
+++ b/sparsify/config.py
@@ -103,8 +103,10 @@ class TrainConfig(Serializable):
 
     save_best: bool = False
     """Save the best checkpoint found for each hookpoint."""
+
     eval_every: int = 300
-    """eval steps """
+    """Run evaluation every N training steps (optionally)."""
+
     finetune: str | None = None
     """Finetune the sparse coders from a pretrained checkpoint."""
 

--- a/sparsify/hooks.py
+++ b/sparsify/hooks.py
@@ -1,0 +1,198 @@
+from contextlib import contextmanager
+from functools import partial
+from typing import Any
+
+import torch.nn.functional as F
+from torch import Tensor, nn
+from transformers import PreTrainedModel
+
+from sparsify import SparseCoder
+
+
+def sparsify_forward(sparse_model: SparseCoder, input: Tensor, device: str) -> Tensor:
+    """Helper method to process an input through a sparse model.
+    Handles flattening and unflattening."""
+    unflattened = [input.shape[0], input.shape[1]]
+
+    return (
+        sparse_model.forward(input.flatten(0, 1))
+        .sae_out.unflatten(dim=0, sizes=unflattened)
+        .to(device)
+    )
+
+
+@contextmanager
+def edit_for_generation(
+    model: PreTrainedModel,
+    hookpoints: list[str],
+    sparse_models: dict[str, SparseCoder],
+    device="cuda",
+):
+    """
+    Context manager that splices a sparse model
+    into a base model.
+
+    Args:
+        model: The transformer model to hook
+        hookpoints: List of hookpoints to edit
+        sparse_models: Dictionary of sparse models to use for editing
+        device: Device to use for editing
+
+    Yields:
+        None
+    """
+    handles = []
+
+    def create_edit_hook(hookpoint: str):
+        def hook_fn(
+            module: nn.Module, input: Any, output: Tensor
+        ) -> Tensor | tuple[Tensor, ...]:
+            tensor_input = input[0] if isinstance(input, tuple) else input
+
+            if isinstance(output, tuple):
+                sparse_forward_input = (
+                    tensor_input
+                    if sparse_models[hookpoint].cfg.transcode
+                    else output[0]
+                )
+                edited_tensor = sparsify_forward(
+                    sparse_models[hookpoint], sparse_forward_input, device
+                )
+                return (edited_tensor, *output[1:])
+            else:
+                sparse_forward_input = (
+                    tensor_input if sparse_models[hookpoint].cfg.transcode else output
+                )
+                return sparsify_forward(
+                    sparse_models[hookpoint], sparse_forward_input, device
+                )
+
+        return hook_fn
+
+    for name, module in model.named_modules():
+        if name in hookpoints:
+            handle = module.register_forward_hook(create_edit_hook(name))
+            handles.append(handle)
+    try:
+        yield None
+    finally:
+        for handle in handles:
+            handle.remove()
+
+
+@contextmanager
+def edit_with_mse(
+    model: PreTrainedModel,
+    hookpoints: list[str],
+    sparse_models: dict[str, SparseCoder],
+    device="cuda",
+):
+    """
+    Context manager that temporarily hooks a model, edits the forward pass,
+    and computes reconstruction MSE loss.
+
+    Args:
+        model: The transformer model to hook
+        hookpoints: List of hookpoints to edit
+        sparse_models: Dictionary of sparse models to use for editing
+        device: Device to use for editing
+
+    Yields:
+        Dictionary mapping hookpoints to their reconstruction MSE loss
+    """
+    handles = []
+    mses = {}
+
+    def create_edit_hook(hookpoint: str):
+        def hook_fn(
+            module: nn.Module, input: Any, output: Tensor
+        ) -> Tensor | tuple[Tensor, ...]:
+            tensor_input = input[0] if isinstance(input, tuple) else input
+
+            if isinstance(output, tuple):
+                sparse_forward_input = (
+                    tensor_input
+                    if sparse_models[hookpoint].cfg.transcode
+                    else output[0]
+                )
+                encoding = sparsify_forward(
+                    sparse_models[hookpoint], sparse_forward_input, device
+                )
+                mses[hookpoint] = F.mse_loss(output[0], encoding)
+                return (encoding, *output[1:])
+            else:
+                sparse_forward_input = (
+                    tensor_input if sparse_models[hookpoint].cfg.transcode else output
+                )
+                encoding = sparsify_forward(
+                    sparse_models[hookpoint], sparse_forward_input, device
+                )
+                mses[hookpoint] = F.mse_loss(output, encoding)
+                return encoding
+
+        return hook_fn
+
+    for name, module in model.named_modules():
+        if name in hookpoints:
+            handle = module.register_forward_hook(create_edit_hook(name))
+            handles.append(handle)
+    try:
+        yield mses
+    finally:
+        for handle in handles:
+            handle.remove()
+
+
+@contextmanager
+def collect_activations(
+    model: PreTrainedModel, hookpoints: list[str], input_acts: bool = False
+):
+    """
+    Context manager that hooks a model and collects activations.
+    An activation tensor is produced for each batch processed and stored
+    in added to a list for that hookpoint in the activations dictionary.
+
+    Args:
+        model: The transformer model to hook
+        hookpoints: List of hookpoints to collect activations from
+        input_acts: Whether to collect input activations or output activations
+
+    Yields:
+        Dictionary mapping hookpoints to their collected activations
+    """
+    activations = {}
+    handles = []
+
+    def create_input_hook(hookpoint: str):
+        def input_hook(module: nn.Module, input: Any, output: Any) -> None:
+            if isinstance(input, tuple):
+                activations[hookpoint] = input[0]
+            else:
+                activations[hookpoint] = input
+
+        return input_hook
+
+    def create_output_hook(hookpoint: str):
+        def output_hook(module: nn.Module, input: Any, output: Any) -> None:
+            if isinstance(output, tuple):
+                activations[hookpoint] = output[0]
+            else:
+                activations[hookpoint] = output
+
+        return output_hook
+
+    for name, module in model.named_modules():
+        if name in hookpoints:
+            hook = create_input_hook(name) if input_acts else create_output_hook(name)
+            handle = module.register_forward_hook(hook)
+            handles.append(handle)
+
+    try:
+        yield activations
+    finally:
+        for handle in handles:
+            handle.remove()
+
+
+collect_input_activations = partial(collect_activations, input_acts=True)
+collect_output_activations = partial(collect_activations, input_acts=False)

--- a/sparsify/trainer.py
+++ b/sparsify/trainer.py
@@ -704,7 +704,8 @@ class Trainer:
             dist.barrier()
     @torch.no_grad()
     def evaluate(self, eval_dataset, step: int):
-        """Run eval set through spliced vs unspliced model, compute mean KL divergence."""
+        """Run eval set through spliced vs unspliced model, 
+        compute mean KL divergence."""
         if eval_dataset is None:
             return
 

--- a/sparsify/utils.py
+++ b/sparsify/utils.py
@@ -40,7 +40,6 @@ def kl_divergence(
     """
     log_p = F.log_softmax(logit_p, dim=dim)
     log_q = F.log_softmax(logit_q, dim=dim)
-    print(log_p)
     p = log_p.exp()
     kl = torch.sum(p * (log_p - log_q), dim=dim)
 

--- a/sparsify/utils.py
+++ b/sparsify/utils.py
@@ -35,12 +35,9 @@ def kl_divergence(
     Compute the KL divergence KL(P || Q) between two sets of logits.
     Both logit_p and logit_q are unnormalized scores (logits).
     """
-    # Turn logits into log-probs
-    # print(logit_p)
     log_p = F.log_softmax(logit_p, dim=dim)
     log_q = F.log_softmax(logit_q, dim=dim)
     print(log_p)
-    # Convert to probabilities
     p = log_p.exp()
     kl = torch.sum(p * (log_p - log_q), dim=dim)
 


### PR DESCRIPTION
@luciaquirke this is the PR for the issue #100 

### Subtasks

- **Support test subset specification**
  - Add an `eval_split` flag to `__main__`.
  - Constrain this to come from the same HF dataset (consistent with existing `split`).

- **Add evaluation function**
  - Implement `evaluate(eval_dataset, step)` method.
  - Run two forward passes:
    - **Unspliced**: base model logits.
    - **Spliced**: with SAE hook(s) enabled.
  - Use hooks from the README to splice SAEs in efficiently.

- **Accumulate KL divergence**
  - Use a stable KL divergence implementation .
  - Average results over the entire evaluation set.

- **W&B logging**
  - Log `mean_kl` at each checkpoint save step.
